### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/t-k/swr-firestore/security/code-scanning/1](https://github.com/t-k/swr-firestore/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required. Based on the workflow steps:
- The `actions/checkout` step requires `contents: read` to access the repository code.
- The `codecov/codecov-action` step does not require additional permissions because it uses a secret token for authentication.

We will set `contents: read` as the minimal required permission for the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
